### PR TITLE
tweak to hid csv vars from infobox

### DIFF
--- a/lib/Map/TableDataSource.js
+++ b/lib/Map/TableDataSource.js
@@ -240,6 +240,10 @@ TableDataSource.prototype.describe = function(properties) {
         if (properties.hasOwnProperty(key)) {
             var value = properties[key];
             if (defined(value)) {
+                    //see if we should skip this in the details - starts with __
+                if (key.substring(0, 2) === '__') {
+                    continue;
+                }
                 if (value instanceof JulianDate) {
 //                    value = JulianDate.toIso8601(value, 0);
                     value = JulianDate.toDate(value).toDateString();


### PR DESCRIPTION
For table data if the variable starts with '__' then it won't show up in the infobox.  Necessary for the UN project and will probably come in handy elsewhere.  If we find that particular substring to be problematic we can look into something more unique.