### PR TITLE
CKAN improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,3 +12,6 @@ Change Log
 * Fixed a bug that caused features to be picked from all layers in an Esri MapServer, instead of just the visible ones.
 * Added support for the WMS MinScaleDenominator property and the Esri MapServer maxScale property, preventing layers from disappearing when zoomed in to close to the surface.
 * Polygons loaded from KML files are now placed on the terrain surface.
+* All catalog items now have an `info` property that allows arbitrary sections to be shown for the item in the info popup.
+* `CkanCatalogGroup` now has a `groupBy` property to control whether catalog items are grouped by CKAN group ("group"), CKAN organization ("organization"), or not grouped at all ("none").
+* `CkanCatalogGroup` now has a `useResourceName` property to control whether the name of the catalog item is derived from the resource (true), or the dataset itself (false).

--- a/lib/Models/CatalogMember.js
+++ b/lib/Models/CatalogMember.js
@@ -63,6 +63,8 @@ var CatalogMember = function(application) {
     knockout.track(this, ['name', 'info', 'description', 'isUserSupplied']);
 };
 
+var descriptionRegex = /description/i;
+
 defineProperties(CatalogMember.prototype, {
     /**
      * Gets the type of data item represented by this instance.
@@ -149,9 +151,8 @@ defineProperties(CatalogMember.prototype, {
             return this.description ||
                 (this.info &&
                  this.info.some(function(i){
-                    return (i.name === "Description" || i.name === "description");
-                    })
-                );
+                    return descriptionRegex.test(i.name);
+                }));
         }
     }
 });

--- a/lib/Models/CkanCatalogGroup.js
+++ b/lib/Models/CkanCatalogGroup.js
@@ -92,11 +92,27 @@ var CkanCatalogGroup = function(application) {
      */
     this.wmsParameters = undefined;
 
+    /**
+     * Gets or sets a value indicating how datasets should be grouped.  Valid values are:
+     * * `none` - Datasets are put in a flat list; they are not grouped at all.
+     * * `group` - Datasets are grouped according to their CKAN group.  Datasets that are not in any groups are put at the top level.
+     * * `organization` - Datasets are grouped by their CKAN organization.  Datasets that are not associated with an organization are put at the top level.
+     * @type {String}
+     */
+    this.groupBy = 'group';
+
+    /**
+     * Gets or sets a value indicating whether each catalog item's name should be populated from
+     * individual resources instead of from the CKAN dataset.
+     * @type {Boolean}
+     */
+    this.useResourceName = false;
+
     this.includeWms = true;
     this.includeKml = false;
     this.includeEsriMapServer = false;
 
-    knockout.track(this, ['url', 'dataCustodian', 'filterQuery', 'blacklist', 'wmsParameters']);
+    knockout.track(this, ['url', 'dataCustodian', 'filterQuery', 'blacklist', 'wmsParameters', 'groupBy', 'useResourceName']);
 };
 
 inherit(CatalogGroup, CkanCatalogGroup);
@@ -441,8 +457,24 @@ function populateGroupFromResults(ckanGroup, json) {
                 continue;
             }
 
-            newItem.name = item.title;
-            newItem.description = textDescription;
+            if (ckanGroup.useResourceName) {
+                newItem.name = resource.name;
+            } else {
+                newItem.name = item.title;
+            }
+
+            newItem.info.push({
+                name: 'Dataset Description',
+                content: textDescription
+            });
+
+            if (defined(resource.description)) {
+                newItem.info.push({
+                    name: 'Resource Description',
+                    content: resource.description.replace(/\n/g, '<br/>')
+                });
+            }
+
             newItem.url = url;
             newItem.rectangle = rectangle;
             newItem.dataUrl = dataUrl;
@@ -460,30 +492,36 @@ function populateGroupFromResults(ckanGroup, json) {
                 newItem.dataCustodian = item.organization.description || item.organization.title;
             }
 
-            //if no groups then use organization
-            var groups = item.groups;
-            if (!defined(groups) || groups.length === 0 || dataGovCkan) {
+            var groups;
+            if (ckanGroup.groupBy === 'group') {
+                groups = item.groups;
+            } else if (ckanGroup.groupBy === 'organization') {
                 groups = [item.organization];
             }
-            for (var groupIndex = 0; groupIndex < groups.length; ++groupIndex) {
-                var group = groups[groupIndex];
-                var groupName = group.display_name || group.title;
-                if (groupName.indexOf(',') !== -1) {
-                    groupName = groupName.substring(0, groupName.indexOf(','));
-                }
 
-                if (ckanGroup.blacklist && ckanGroup.blacklist[groupName]) {
-                    continue;
-                }
+            if (defined(groups) && groups.length > 0) {
+                for (var groupIndex = 0; groupIndex < groups.length; ++groupIndex) {
+                    var group = groups[groupIndex];
+                    var groupName = group.display_name || group.title;
+                    if (groupName.indexOf(',') !== -1) {
+                        groupName = groupName.substring(0, groupName.indexOf(','));
+                    }
 
-                var existingGroup = ckanGroup.findFirstItemByName(groupName);
-                if (!defined(existingGroup)) {
-                    existingGroup = new CatalogGroup(ckanGroup.application);
-                    existingGroup.name = groupName;
-                    ckanGroup.add(existingGroup);
-                }
+                    if (ckanGroup.blacklist && ckanGroup.blacklist[groupName]) {
+                        continue;
+                    }
 
-                existingGroup.add(newItem);
+                    var existingGroup = ckanGroup.findFirstItemByName(groupName);
+                    if (!defined(existingGroup)) {
+                        existingGroup = new CatalogGroup(ckanGroup.application);
+                        existingGroup.name = groupName;
+                        ckanGroup.add(existingGroup);
+                    }
+
+                    existingGroup.add(newItem);
+                }
+            } else {
+                ckanGroup.add(newItem);
             }
         }
     }
@@ -503,7 +541,9 @@ function populateGroupFromResults(ckanGroup, json) {
     ckanGroup.items.sort(compareNames);
 
     for (var i = 0; i < ckanGroup.items.length; ++i) {
-        ckanGroup.items[i].items.sort(compareNames);
+        if (defined(ckanGroup.items[i].items)) {
+            ckanGroup.items[i].items.sort(compareNames);
+        }
     }
 }
 

--- a/lib/Views/CatalogItemInfo.html
+++ b/lib/Views/CatalogItemInfo.html
@@ -52,14 +52,14 @@
             <!-- /ko -->
 
 
-        <!-- ko foreach: catalogItem.info -->
+            <!-- ko foreach: catalogItem.info -->
             <div class="catalog-item-info-section">
                 <h2 data-bind="text: name"></h2>
                 <div class="catalog-item-info-description">
                     <div data-bind="sanitizedHtml: content"></div>
                 </div>
             </div>
-        <!-- /ko -->
+            <!-- /ko -->
 
             <div class="catalog-item-info-section" data-bind="if: catalogItem.url">
                 <h2><span data-bind="text: catalogItem.typeName"></span> URL</h2>
@@ -92,12 +92,12 @@
                     <table data-bind="template: { name: 'catalog-item-info-item-template', foreach: catalogItem.metadata.dataSourceMetadata.items }">
                     </table>
                     <!-- /ko -->
-                    <!-- ko if: catalogItem.metadata.catalogItemErrorMessage -->
+                    <!-- ko if: catalogItem.metadata.dataSourceErrorMessage -->
                     <table>
                         <tr>
                             <td class="catalog-item-info-properties-name-cell catalog-item-info-properties-level1">
                                 <div class="catalog-item-info-properties-arrow"></div>
-                                <div class="catalog-item-info-properties-name" data-bind="text: catalogItem.metadata.catalogItemErrorMessage"></div>
+                                <div class="catalog-item-info-properties-name" data-bind="text: catalogItem.metadata.dataSourceErrorMessage"></div>
                             </td>
                         </tr>
                     </table>


### PR DESCRIPTION
* `CkanCatalogGroup` now has a `groupBy` property to control whether catalog items are grouped by CKAN group ("group"), CKAN organization ("organization"), or not grouped at all ("none").
* `CkanCatalogGroup` now has a `useResourceName` property to control whether the name of the catalog item is derived from the resource (true), or the dataset itself (false).

This is in support of TIND.