### PR TITLE
No haiku for empty groups.

### DIFF
--- a/lib/Views/DataCatalogTab.html
+++ b/lib/Views/DataCatalogTab.html
@@ -26,8 +26,10 @@
             <!-- ko if: isOpen && (isLoading || items.length === 0) -->
                 <div class="data-catalog-group-contents">
                     <div class="data-catalog-member" data-bind="css: 'data-catalog-indent' + ($parents.length - 1)">
-                        <div class="data-catalog-item-label" data-bind="if: isLoading">Loading...</div>
-                        <div class="data-catalog-item-label" data-bind="if: !isLoading">This group does not contain any data items.</div>
+                        <div class="data-catalog-member-top-row">
+                            <div class="data-catalog-item-label" data-bind="visible: isLoading">Loading...</div>
+                            <div class="data-catalog-item-label" data-bind="visible: !isLoading">This group does not contain any items.</div>
+                        </div>
                     </div>
                 </div>
             <!-- /ko -->
@@ -48,7 +50,7 @@
     </div>
     <!-- ko if: isLoading -->
         <div class="data-catalog-top-group-contents">
-            <div class="data-catalog-member">
+            <div class="data-catalog-member data-catalog-indent0">
                 <div class="data-catalog-member-top-row">
                     <div class="data-catalog-item-label">Loading...</div>
                 </div>
@@ -56,6 +58,13 @@
         </div>
     <!-- /ko -->
     <!-- ko if: typeof items !== 'undefined' && isOpen -->
+        <div class="data-catalog-top-group-contents" data-bind="visible: items.length === 0 && !isLoading">
+            <div class="data-catalog-member data-catalog-indent0">
+                <div class="data-catalog-member-top-row">
+                    <div class="data-catalog-item-label">This group does not contain any items.</div>
+                </div>
+            </div>
+        </div>
         <div class="data-catalog-top-group-contents" data-bind="template: { name: 'data-catalog-item-template', foreach: items }"></div>
     <!-- /ko -->
 </div>


### PR DESCRIPTION
Also display a "no items" message when a top-level group is empty.

Fixes NICTA/nationalmap#633